### PR TITLE
webtests-osx-fix : HeaderTool extension changed

### DIFF
--- a/support/modules/cucumberselenium/webdriver.rb
+++ b/support/modules/cucumberselenium/webdriver.rb
@@ -30,7 +30,7 @@ module CucumberSelenium::WebDriverHelper
       profile["extensions.headertool.preferencies.onoff"] = true
       enc = Base64.encode64 "#{test_config['basic_auth']['username']}:#{test_config['basic_auth']['password']}"
       profile["extensions.headertool.preferencies.editor"] = "Authorization : Basic #{enc}"
-      profile.add_extension "#{test_config['firefox']['addon_dir']}/ht_0.5.1.xpi"
+      profile.add_extension "#{test_config['firefox']['addon_dir']}/ht_0.6.1.xpi"
   end
 
   def start_sauce_labs_browser(caps)


### PR DESCRIPTION
Along with the change of the selenium webdriver version in grid-packages (https://github.com/commercetools/grid-packages/commit/0c9487a1fb3418d60fc9845ff8cfc105d73cfbd2), the headertool extension is also unsigned and won't work for current firefox.
the new version is signed, hence this modification.
